### PR TITLE
force default encoding in zarafa-spamhandler.py

### DIFF
--- a/scripts/zarafa-spamhandler/zarafa-spamhandler.py
+++ b/scripts/zarafa-spamhandler/zarafa-spamhandler.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import ConfigParser
 import sys
 import subprocess


### PR DESCRIPTION
had otherwise problems running the script from cron, e.g. "UnicodeEncodeError: 'ascii' codec can't encode character"
