### PR TITLE
Improve User lookup performance (fixes issue #29)

### DIFF
--- a/zarafa/__init__.py
+++ b/zarafa/__init__.py
@@ -2629,7 +2629,13 @@ class User(object):
             self._ecuser = self.server.sa.GetUser(self.server.sa.ResolveUserName(self._name, MAPI_UNICODE), MAPI_UNICODE)
         except MAPIErrorNotFound:
             raise ZarafaException("no such user: '%s'" % name)
-        self.mapiobj = self.server.mapisession.OpenEntry(self._ecuser.UserID, None, 0)
+        self._mapiobj = None
+
+    @property
+    def mapiobj(self):
+        if not self._mapiobj:
+            self._mapiobj = self.server.mapisession.OpenEntry(self._ecuser.UserID, None, 0)
+        return self._mapiobj
 
     @property
     def name(self):


### PR DESCRIPTION
The previous code always tried to retrieve the underlying mapiobj.
This is not always needed and may involve multiple network round-trips.
Therefore, this commit lazy-loads the mapiobj instance so that simple
user attribute retrieval can be executed without loading this object
at all.